### PR TITLE
fix panic occurs when using Float value

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -35,12 +35,36 @@ func (s *Stack) Push(val VarValue) {
 
 	switch val.(type) {
 	case int64:
-		if s.Max == nil || val.(int64) > s.Max.(int64) {
+		if s.Max == nil {
 			s.Max = val
+			return
+		}
+
+		switch s.Max.(type) {
+		case int64:
+			if val.(int64) > s.Max.(int64) {
+				s.Max = val
+			}
+		case float64:
+			if float64(val.(int64)) > s.Max.(float64) {
+				s.Max = val
+			}
 		}
 	case float64:
-		if s.Max == nil || val.(float64) > s.Max.(float64) {
+		if s.Max == nil {
 			s.Max = val
+			return
+		}
+
+		switch s.Max.(type) {
+		case int64:
+			if val.(float64) > float64(s.Max.(int64)) {
+				s.Max = val
+			}
+		case float64:
+			if val.(float64) > s.Max.(float64) {
+				s.Max = val
+			}
 		}
 	}
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -2,6 +2,13 @@ package main
 
 import "testing"
 
+func TestPushWithFloatAndIntValue(t *testing.T) {
+	s := NewStack()
+	s.Push(VarValue(int64(0.0))) // from service.go:guessValue
+	s.Push(VarValue(5.0))
+	s.Push(VarValue(float64(15.0)))
+}
+
 func TestStack(t *testing.T) {
 	size := 10
 	s := NewStackWithSize(size)


### PR DESCRIPTION
panic occurs when include zero value

```
panic: interface conversion: interface is float64, not int64

goroutine 338 [running]:
main.(*Stack).Push(0xc820016f30, 0x2b6720, 0xc820328bd0)
    src/github.com/divan/expvarmon/stack.go:38 +0x2a7
main.(*Service).Update(0xc8200b8000, 0xc820196710)
    src/github.com/divan/expvarmon/service.go:89 +0x3ed
created by main.UpdateAll
```

expvarmon is great tool!!
Thanks