### PR TITLE
allow escaping the dot character in paths using a backslash

### DIFF
--- a/var_test.go
+++ b/var_test.go
@@ -44,4 +44,49 @@ func TestVarName(t *testing.T) {
 	if kind != KindDuration {
 		t.Fatalf("Expecting kind to be %v, but got: %v", KindDuration, kind)
 	}
+
+	// single \. escapes the dot
+	v = VarName(`bleve.indexes.bench\.bleve.index.lookup_queue_len`)
+
+	slice = v.ToSlice()
+	if len(slice) != 5 || slice[0] != "bleve" || slice[1] != "indexes" || slice[2] != "bench.bleve" ||
+		slice[3] != "index" || slice[4] != "lookup_queue_len" {
+		t.Fatalf("ToSlice failed: %v", slice)
+	}
+
+	// double \\. escapes backslash, not dot
+	v = VarName(`bleve.indexes.bench\\.bleve.index.lookup_queue_len`)
+
+	slice = v.ToSlice()
+	if len(slice) != 6 || slice[0] != "bleve" || slice[1] != "indexes" || slice[2] != "bench\\" ||
+		slice[3] != "bleve" || slice[4] != "index" || slice[5] != "lookup_queue_len" {
+		t.Fatalf("ToSlice failed: %v", slice)
+	}
+
+	// triple \\\. escapes backslash then dot
+	v = VarName(`bleve.indexes.bench\\\.bleve.index.lookup_queue_len`)
+
+	slice = v.ToSlice()
+	if len(slice) != 5 || slice[0] != "bleve" || slice[1] != "indexes" || slice[2] != "bench\\.bleve" ||
+		slice[3] != "index" || slice[4] != "lookup_queue_len" {
+		t.Fatalf("ToSlice failed: %v", slice)
+	}
+
+	// quadruple \\\\. escapes two backslashes, not dot
+	v = VarName(`bleve.indexes.bench\\\\.bleve.index.lookup_queue_len`)
+
+	slice = v.ToSlice()
+	if len(slice) != 6 || slice[0] != "bleve" || slice[1] != "indexes" || slice[2] != "bench\\\\" ||
+		slice[3] != "bleve" || slice[4] != "index" || slice[5] != "lookup_queue_len" {
+		t.Fatalf("ToSlice failed: %v", slice)
+	}
+
+	// unsupported \x passes through unaltered
+	v = VarName(`bleve.indexes.bench\xbleve.index.lookup_queue_len`)
+
+	slice = v.ToSlice()
+	if len(slice) != 5 || slice[0] != "bleve" || slice[1] != "indexes" || slice[2] != "bench\\xbleve" ||
+		slice[3] != "index" || slice[4] != "lookup_queue_len" {
+		t.Fatalf("ToSlice failed: %v", slice)
+	}
 }


### PR DESCRIPTION
Occasionally expvar output contains keys that are hostnames,
IP addresses, or filenames that contain the "." character.  For
example:

```
{
  "bleve": {
    "bootDuration": 16559,
    "indexes": {
      "bench.bleve": {
        "index": {
          "analysis_time": 10889841135,
          "batches": 145,
          "deletes": 0,
          "errors": 0,
          "index_time": 21277401883,
          "lookup_queue_len": 0,
          "updates": 14500
        },
        "search_time": 0,
        "searches": 0
      }
    }
  }
...
}
```

I can now chart the lookup_queue_len value using the var:

bleve.indexes.bench\\.bleve.index.lookup_queue_len

This partially addresses #11 (still does not escape colon character).