### PR TITLE
Moves the main.go into cmd/expvarmon folder to make it go gettable to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 expvarmon
+!cmd/expvarmon
 *.swp

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Also it doesn't use any storage engines and doesn't send notifications.
 
 Just run go get:
 
-    go get github.com/divan/expvarmon
+    go get github.com/divan/expvarmon/...
 
 ## Usage
 

--- a/average.go
+++ b/average.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"github.com/antonholmquist/jason"

--- a/average_test.go
+++ b/average_test.go
@@ -1,15 +1,15 @@
-package main
+package expvarmon
 
 import (
-	"testing"
+    "testing"
 )
 
 func TestAverage(t *testing.T) {
-	avg := average(samplesPartial)
-	want := 621090.75
-	if avg != want {
-		t.Fatalf("Average must be %v, but got %v", want, avg)
-	}
+    avg := average(samplesPartial)
+    want := 621090.75
+    if avg != want {
+        t.Fatalf("Average must be %v, but got %v", want, avg)
+    }
 }
 
 var samplesPartial = []float64{507472, 433979, 610916, 931996, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}

--- a/data.go
+++ b/data.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import "time"
 
@@ -37,7 +37,7 @@ func NewSparklineData(vars []VarName) *SparklineData {
 // NewUIData inits and return new data object.
 func NewUIData(vars []VarName, services []*Service) *UIData {
 	sp := make([]*SparklineData, len(services))
-	for i, _ := range services {
+	for i := range services {
 		sp[i] = NewSparklineData(vars)
 	}
 

--- a/expvars.go
+++ b/expvars.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"errors"

--- a/expvars_test.go
+++ b/expvars_test.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"os"

--- a/histogram.go
+++ b/histogram.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"math"

--- a/self.go
+++ b/self.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"expvar"

--- a/service.go
+++ b/service.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"net/url"

--- a/stack.go
+++ b/stack.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 // DefaultSize specifies maximum number of items in stack.
 //

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import "testing"
 

--- a/stat.go
+++ b/stat.go
@@ -1,26 +1,26 @@
-package main
+package expvarmon
 
 // Stat holds basic statistics data for
 // integer data used for sparklines.
 type Stat struct {
-	max    int
-	maxStr string
+    max    int
+    maxStr string
 }
 
 // NewStat inits new Stat object.
 func NewStat() *Stat {
-	return &Stat{}
+    return &Stat{}
 }
 
 // Update updates stats on each push.
 func (s *Stat) Update(v IntVar) {
-	if v.Value() > s.max {
-		s.max = v.Value()
-		s.maxStr = v.String()
-	}
+    if v.Value() > s.max {
+        s.max = v.Value()
+        s.maxStr = v.String()
+    }
 }
 
 // Max returns maximum recorded value.
 func (s *Stat) Max() string {
-	return s.maxStr
+    return s.maxStr
 }

--- a/ui.go
+++ b/ui.go
@@ -1,8 +1,8 @@
-package main
+package expvarmon
 
 // UI represents UI renderer.
 type UI interface {
-	Init(UIData) error
-	Close()
-	Update(UIData)
+    Init(UIData) error
+    Close()
+    Update(UIData)
 }

--- a/ui_dummy.go
+++ b/ui_dummy.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"fmt"

--- a/ui_multi.go
+++ b/ui_multi.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"fmt"
@@ -15,6 +15,12 @@ type TermUI struct {
 	Lists      []*termui.List
 	Sparkline1 *termui.Sparklines
 	Sparkline2 *termui.Sparklines
+	interval   time.Duration // interval between refreshes
+}
+
+// NewTermUI constructs the TermUI and sets the interval
+func NewTermUI(interval time.Duration) *TermUI {
+	return &TermUI{interval: interval}
 }
 
 // Init creates widgets, sets sizes and labels.
@@ -92,7 +98,7 @@ func (t *TermUI) Init(data UIData) error {
 
 // Update updates UI widgets from UIData.
 func (t *TermUI) Update(data UIData) {
-	t.Title.Text = fmt.Sprintf("monitoring %d services every %v, press q to quit", len(data.Services), *interval)
+	t.Title.Text = fmt.Sprintf("monitoring %d services every %v, press q to quit", len(data.Services), t.interval)
 	t.Status.Text = fmt.Sprintf("Last update: %v", data.LastTimestamp.Format(time.Stamp))
 
 	// List with service names

--- a/ui_single.go
+++ b/ui_single.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"fmt"
@@ -21,7 +21,13 @@ type TermUISingle struct {
 	GCIChart *termui.BarChart
 	GCIStats *termui.Par
 
-	bins int // histograms' bins count
+	bins     int           // histograms' bins count
+	interval time.Duration // interval between refreshes
+}
+
+// NewTermUISingle constructs the TermUISingle and sets the interval
+func NewTermUISingle(interval time.Duration) *TermUISingle {
+	return &TermUISingle{interval: interval}
 }
 
 // Init creates widgets, sets sizes and labels.
@@ -128,7 +134,7 @@ func (t *TermUISingle) Update(data UIData) {
 	// single mode assumes we have one service only to monitor
 	service := data.Services[0]
 
-	t.Title.Text = fmt.Sprintf("monitoring %s every %v, press q to quit", service.Name, *interval)
+	t.Title.Text = fmt.Sprintf("monitoring %s every %v, press q to quit", service.Name, t.interval)
 	t.Status.Text = fmt.Sprintf("Last update: %v", data.LastTimestamp.Format(time.Stamp))
 
 	// Pars

--- a/ui_single_test.go
+++ b/ui_single_test.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import "testing"
 

--- a/utils.go
+++ b/utils.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"errors"

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import "testing"
 

--- a/var.go
+++ b/var.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"fmt"

--- a/var_test.go
+++ b/var_test.go
@@ -1,4 +1,4 @@
-package main
+package expvarmon
 
 import (
 	"strings"


### PR DESCRIPTION
Moves the main.go into cmd/expvarmon. This way people can install different versions of executables and use expvarmon as a library. It also fixed undefined DefaultEndpoint when I tried to run the main. Also I would create another cmd/expvardummon (or any other names you like) to separate the dummy prints with the normal ones.

Please note that I passed the interval to constructors for the following reasons:

- It is a configuration value
- Once it is set, it is not supposed to be changed, hence unexported variable.
